### PR TITLE
Refine service health handling and metrics tracking

### DIFF
--- a/app/api/v1/health.py
+++ b/app/api/v1/health.py
@@ -1,8 +1,9 @@
 """Health check endpoints."""
 
+import inspect
 import time
 from datetime import datetime
-from typing import Dict, Any
+from typing import Any, Callable, Dict
 
 from fastapi import APIRouter, status
 from pydantic import BaseModel
@@ -29,6 +30,71 @@ class HealthResponse(BaseModel):
 _start_time = time.time()
 
 
+async def _safe_check(
+    component_name: str,
+    check_fn: Callable[[], Any],
+    mapper: Callable[[Any], Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Execute a health check function safely and map the result."""
+
+    try:
+        result = check_fn()
+        if inspect.isawaitable(result):
+            result = await result
+
+        mapped = mapper(result)
+        if "status" not in mapped:
+            raise ValueError("Component mapper must include a 'status' field")
+        return mapped
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logger.exception(
+            "Health check component failure",
+            extra={"component": component_name},
+        )
+        human_readable = component_name.replace("_", " ")
+        return {
+            "status": "unhealthy",
+            "message": f"{human_readable} error: {exc}",
+        }
+
+
+async def _get_index_stats() -> Dict[str, Any]:
+    from app.services.indexing_service import indexing_service
+
+    return await indexing_service.get_index_stats()
+
+
+async def _get_embedding_health() -> Dict[str, Any]:
+    from app.services.indexing_service import indexing_service
+
+    return await indexing_service.health_check()
+
+
+async def _get_llm_health() -> Dict[str, Any]:
+    from app.services.llm import llm_service
+
+    return await llm_service.health_check()
+
+
+async def _get_sync_status() -> Dict[str, Any]:
+    from app.services.sync_service import sync_service
+
+    return await sync_service.get_sync_status()
+
+
+def _get_solarwinds_configuration() -> Dict[str, Any]:
+    from app.services.solarwinds import solarwinds_service
+
+    client = getattr(solarwinds_service, "client", None)
+    configured = bool(client and client.api_key)
+    message = (
+        "SolarWinds API configured"
+        if configured
+        else "SolarWinds API not configured"
+    )
+    return {"configured": configured, "message": message}
+
+
 @router.get(
     "/health",
     response_model=HealthResponse,
@@ -53,95 +119,66 @@ async def health_check() -> HealthResponse:
         "logging": {"status": "healthy", "message": "Logging system operational"},
     }
 
-    # Indexing and embedding services
-    try:
-        from app.services.indexing_service import indexing_service
+    service_checks = [
+        (
+            "vector_store",
+            _get_index_stats,
+            lambda stats: {
+                "status": "healthy" if stats.get("initialized") else "degraded",
+                "message": (
+                    "Vector store operational"
+                    if stats.get("initialized")
+                    else stats.get("error", "Service not initialized")
+                ),
+            },
+        ),
+        (
+            "embedding_service",
+            _get_embedding_health,
+            lambda health: {
+                "status": "healthy" if health.get("healthy") else "degraded",
+                "message": health.get("error") or "Embedding service operational",
+            },
+        ),
+        (
+            "llm_service",
+            _get_llm_health,
+            lambda health: {
+                "status": health.get("status", "unknown"),
+                "message": health.get("error")
+                or f"Provider: {health.get('provider', 'unknown')}",
+            },
+        ),
+        (
+            "sync_service",
+            _get_sync_status,
+            lambda sync_status: {
+                "status": "healthy"
+                if sync_status.get("service_running")
+                else "degraded",
+                "message": (
+                    "Sync service running"
+                    if sync_status.get("service_running")
+                    else "Sync service not running"
+                ),
+            },
+        ),
+        (
+            "solarwinds_api",
+            _get_solarwinds_configuration,
+            lambda config: {
+                "status": "healthy" if config.get("configured") else "disabled",
+                "message": config.get("message", "SolarWinds API not configured"),
+            },
+        ),
+    ]
 
-        stats = await indexing_service.get_index_stats()
-        health = await indexing_service.health_check()
-
-        if stats.get("initialized") and health.get("healthy"):
-            components["vector_store"] = {
-                "status": "healthy",
-                "message": "Vector store operational",
-            }
-            components["embedding_service"] = {
-                "status": "healthy",
-                "message": "Embedding service operational",
-            }
-        else:
-            error_message = health.get("error") or stats.get("error") or "Service not initialized"
-            components["vector_store"] = {
-                "status": "degraded",
-                "message": error_message,
-            }
-            components["embedding_service"] = {
-                "status": "degraded",
-                "message": error_message,
-            }
-    except Exception as exc:
-        message = str(exc)
-        components["vector_store"] = {
-            "status": "unhealthy",
-            "message": f"Vector store error: {message}",
-        }
-        components["embedding_service"] = {
-            "status": "unhealthy",
-            "message": f"Embedding error: {message}",
-        }
-
-    # LLM provider
-    try:
-        from app.services.llm import llm_service
-
-        llm_status = await llm_service.health_check()
-        components["llm_service"] = {
-            "status": llm_status.get("status", "unknown"),
-            "message": llm_status.get("error")
-            or f"Provider: {llm_status.get('provider', 'unknown')}",
-        }
-    except Exception as exc:
-        components["llm_service"] = {
-            "status": "unhealthy",
-            "message": f"LLM service error: {str(exc)}",
-        }
-
-    # Sync service
-    try:
-        from app.services.sync_service import sync_service
-
-        sync_status = await sync_service.get_sync_status()
-        components["sync_service"] = {
-            "status": "healthy" if sync_status.get("service_running") else "degraded",
-            "message": "Sync service running"
-            if sync_status.get("service_running")
-            else "Sync service not running",
-        }
-    except Exception as exc:
-        components["sync_service"] = {
-            "status": "unhealthy",
-            "message": f"Sync service error: {str(exc)}",
-        }
-
-    # SolarWinds API configuration
-    try:
-        from app.services.solarwinds import solarwinds_service
-
-        if getattr(solarwinds_service, "client", None) and solarwinds_service.client.api_key:
-            components["solarwinds_api"] = {
-                "status": "healthy",
-                "message": "SolarWinds API configured",
-            }
-        else:
-            components["solarwinds_api"] = {
-                "status": "disabled",
-                "message": "SolarWinds API not configured",
-            }
-    except Exception as exc:
-        components["solarwinds_api"] = {
-            "status": "unhealthy",
-            "message": f"SolarWinds error: {str(exc)}",
-        }
+    for component_name, check_fn, mapper in service_checks:
+        components[component_name] = await _safe_check(
+            component_name,
+            check_fn,
+            mapper,
+        )
     
     logger.info("Health check requested", extra={
         "uptime_seconds": uptime,

--- a/app/api/v1/metrics.py
+++ b/app/api/v1/metrics.py
@@ -1,5 +1,6 @@
 """Metrics endpoints for monitoring and observability."""
 
+import asyncio
 import time
 from datetime import datetime
 from typing import Any, Dict
@@ -57,6 +58,21 @@ class MetricsResponse(BaseModel):
 # Store application start time for uptime calculation
 _start_time = time.time()
 _total_requests = 0
+_request_counter_lock: asyncio.Lock | None = None
+
+
+async def _increment_request_count() -> int:
+    """Increment the total request counter in a thread-safe manner."""
+
+    global _total_requests
+    global _request_counter_lock
+
+    if _request_counter_lock is None:
+        _request_counter_lock = asyncio.Lock()
+
+    async with _request_counter_lock:
+        _total_requests += 1
+        return _total_requests
 
 
 @router.get(
@@ -74,10 +90,8 @@ async def get_metrics() -> MetricsResponse:
         ApplicationMetrics: Current application and system metrics
     """
     current_time = time.time()
-    global _total_requests
-
     uptime = current_time - _start_time
-    _total_requests += 1
+    total_requests = await _increment_request_count()
     
     # Get system metrics
     cpu_percent = psutil.cpu_percent(interval=0.1)
@@ -94,7 +108,7 @@ async def get_metrics() -> MetricsResponse:
 
     application_metrics = ApplicationSection(
         uptime_seconds=uptime,
-        total_requests=_total_requests,
+        total_requests=total_requests,
         active_connections=0,
         version="1.0.0",
         environment="development" if settings.debug else "production",
@@ -107,7 +121,7 @@ async def get_metrics() -> MetricsResponse:
         "cpu_percent": cpu_percent,
         "memory_percent": memory.percent,
         "uptime_seconds": uptime,
-        "total_requests": _total_requests,
+        "total_requests": total_requests,
     })
 
     return MetricsResponse(

--- a/app/api/v1/solutions.py
+++ b/app/api/v1/solutions.py
@@ -10,6 +10,7 @@ from app.services.sync_service import sync_service
 from app.services.solarwinds import solarwinds_service
 from app.services.indexing_service import indexing_service
 from app.core.logging import get_logger
+from app.core.exceptions import SolarWindsChatbotException
 
 logger = get_logger(__name__)
 
@@ -47,9 +48,20 @@ async def list_solutions(
         # TODO: Implement proper listing functionality in vector store
         return []
         
-    except Exception as e:
-        logger.error(f"Error listing solutions: {str(e)}")
-        return []
+    except SolarWindsChatbotException as exc:
+        log_extra = {"error": exc.message}
+        log_extra.update(exc.details)
+        logger.error(
+            "Error listing solutions",
+            extra=log_extra,
+        )
+        raise HTTPException(status_code=exc.status_code, detail=exc.message)
+    except Exception as exc:
+        logger.exception("Error listing solutions")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list solutions: {str(exc)}",
+        )
 
 
 @router.get("/solutions/sync-status", response_model=Dict[str, Any])
@@ -186,11 +198,22 @@ async def search_solutions(
         
         return [result.model_dump() for result in results]
         
+    except SolarWindsChatbotException as exc:
+        log_extra = {"error": exc.message}
+        log_extra.update(exc.details)
+        logger.error(
+            "Indexing service error during solution search",
+            extra=log_extra,
+        )
+        raise HTTPException(status_code=exc.status_code, detail=exc.message)
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error searching solutions: {str(e)}")
-        return []
+    except Exception as exc:
+        logger.exception("Error searching solutions")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to search solutions: {str(exc)}",
+        )
 
 
 @router.get("/solutions/stats")
@@ -242,11 +265,19 @@ async def get_solution(solution_id: str) -> Dict[str, Any]:
         
         return solution.model_dump()
         
+    except SolarWindsChatbotException as exc:
+        log_extra = {"error": exc.message}
+        log_extra.update(exc.details)
+        logger.error(
+            "Indexing service error when getting solution",
+            extra=log_extra,
+        )
+        raise HTTPException(status_code=exc.status_code, detail=exc.message)
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error getting solution: {str(e)}")
+    except Exception as exc:
+        logger.exception("Error getting solution")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get solution: {str(e)}"
+            detail=f"Failed to get solution: {str(exc)}"
         )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,7 +7,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Application settings."""
+    """Application settings.
+
+    The defaults favor the OpenRouter LLM provider and OpenAI embeddings for a
+    fully hosted experience. Override any field via environment variables when
+    working with local providers to preserve existing development workflows.
+    """
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -78,11 +83,4 @@ class Settings(BaseSettings):
 
 
 # Global settings instance
-# Create settings with explicit environment variables for development
-import os
-os.environ.setdefault('DEBUG', 'false')
-os.environ.setdefault('LLM_PROVIDER', 'openrouter')
-os.environ.setdefault('EMBEDDING_PROVIDER', 'openai')
-os.environ.setdefault('REDIS_ENABLED', 'false')
-
 settings = Settings()

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -39,6 +39,13 @@ class VectorStoreError(SolarWindsChatbotException):
         super().__init__(message, details, status_code=503)
 
 
+class IndexingServiceError(SolarWindsChatbotException):
+    """Raised when the indexing service is unavailable or encounters errors."""
+
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(message, details, status_code=503)
+
+
 class LLMProviderError(SolarWindsChatbotException):
     """Raised when LLM provider operations fail."""
 

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -21,10 +21,9 @@ class ChatRequest(BaseModel):
     @classmethod
     def validate_query(cls, value: str) -> str:
         """Ensure the query contains non-whitespace characters."""
-        cleaned = value.strip()
-        if not cleaned:
-            raise ValueError("Query must contain non-whitespace characters.")
-        return cleaned
+        if cleaned := value.strip():
+            return cleaned
+        raise ValueError("Query must contain non-whitespace characters.")
 
 
 class SourceDoc(BaseModel):

--- a/app/services/indexing_service.py
+++ b/app/services/indexing_service.py
@@ -4,7 +4,11 @@ import asyncio
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 
-from app.core.exceptions import VectorStoreError, EmbeddingError
+from app.core.exceptions import (
+    VectorStoreError,
+    EmbeddingError,
+    IndexingServiceError,
+)
 from app.core.logging import get_logger
 from app.models.schemas import SolutionRecord, SourceDoc
 from app.services.embedding import embedding_service
@@ -315,43 +319,75 @@ class IndexingService:
         Returns:
             List of source documents with similarity scores
         """
-        if not self._initialized:
-            await self.initialize()
-
-            if not self._initialized:
-                logger.warning(
-                    "Indexing service unavailable; returning empty search results",
-                    extra={"error": self._last_error},
-                )
-                return []
-
         if not query.strip():
             return []
 
+        await self.initialize()
+        if not self._initialized:
+            error_message = self._last_error or "Indexing service not initialized"
+            logger.error(
+                "Indexing service unavailable for search",
+                extra={"error": error_message},
+            )
+            raise IndexingServiceError(
+                "Indexing service unavailable",
+                details={
+                    "operation": "search_solutions",
+                    "error": error_message,
+                },
+            )
+
         try:
-            # Generate embedding for the query
-            query_embedding = await embedding_service.get_embedding(query.strip())
-            
-            # Search vector store
+            query_text = query.strip()
+            query_embedding = await embedding_service.get_embedding(query_text)
+
             results = await vector_store_service.search_similar(
                 query_embedding=query_embedding,
                 top_k=top_k,
                 category_filter=category_filter,
                 min_score=min_score
             )
-            
-            logger.info(f"Search completed", extra={
-                "query": query[:100] + "..." if len(query) > 100 else query,
+
+            truncated_query = (
+                f"{query_text[:100]}..." if len(query_text) > 100 else query_text
+            )
+            logger.info("Search completed", extra={
+                "query": truncated_query,
                 "results_count": len(results),
                 "top_k": top_k,
                 "category_filter": category_filter,
             })
-            
+
             return results
-            
-        except Exception as e:
-            logger.error(f"Error searching solutions: {str(e)}")
-            return []
+
+        except (EmbeddingError, VectorStoreError) as exc:
+            self._last_error = str(exc)
+            logger.exception(
+                "Dependency error during search_solutions",
+                extra={
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                    "query": query,
+                },
+            )
+            raise
+        except Exception as exc:
+            self._last_error = str(exc)
+            logger.exception(
+                "Unexpected error during search_solutions",
+                extra={
+                    "query": query,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            raise IndexingServiceError(
+                "Failed to search solutions",
+                details={
+                    "operation": "search_solutions",
+                    "error": str(exc),
+                },
+            ) from exc
     
     async def get_solution_by_id(self, solution_id: str) -> Optional[SolutionRecord]:
         """
@@ -363,21 +399,49 @@ class IndexingService:
         Returns:
             Solution record if found, None otherwise
         """
+        await self.initialize()
         if not self._initialized:
-            await self.initialize()
-
-            if not self._initialized:
-                logger.warning(
-                    "Indexing service unavailable when fetching solution by ID",
-                    extra={"solution_id": solution_id, "error": self._last_error},
-                )
-                return None
+            error_message = self._last_error or "Indexing service not initialized"
+            logger.error(
+                "Indexing service unavailable when fetching solution by ID",
+                extra={"solution_id": solution_id, "error": error_message},
+            )
+            raise IndexingServiceError(
+                "Indexing service unavailable",
+                details={
+                    "operation": "get_solution_by_id",
+                    "solution_id": solution_id,
+                    "error": error_message,
+                },
+            )
 
         try:
             return await vector_store_service.get_solution_by_id(solution_id)
-        except Exception as e:
-            logger.error(f"Error getting solution by ID '{solution_id}': {str(e)}")
-            return None
+        except VectorStoreError as exc:
+            self._last_error = str(exc)
+            logger.exception(
+                "Vector store error retrieving solution by ID",
+                extra={"solution_id": solution_id},
+            )
+            raise
+        except Exception as exc:
+            self._last_error = str(exc)
+            logger.exception(
+                "Unexpected error retrieving solution by ID",
+                extra={
+                    "solution_id": solution_id,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            raise IndexingServiceError(
+                "Failed to retrieve solution",
+                details={
+                    "operation": "get_solution_by_id",
+                    "solution_id": solution_id,
+                    "error": str(exc),
+                },
+            ) from exc
     
     async def get_index_stats(self) -> Dict[str, Any]:
         """
@@ -387,30 +451,30 @@ class IndexingService:
             Dictionary with index statistics
         """
         try:
-            stats = {}
-            
-            if self._initialized:
-                vector_stats = await vector_store_service.get_collection_stats()
-                embedding_info = await embedding_service.get_service_info()
-
-                stats = {
-                    "initialized": True,
-                    "vector_store": vector_stats,
-                    "embedding_service": embedding_info,
-                }
-            else:
-                stats = {
+            if not self._initialized:
+                return {
                     "initialized": False,
                     "error": self._last_error or "Service not initialized",
                 }
 
-            return stats
+            vector_stats = await vector_store_service.get_collection_stats()
+            embedding_info = await embedding_service.get_service_info()
 
-        except Exception as e:
-            logger.error(f"Error getting index stats: {str(e)}")
+            return {
+                "initialized": True,
+                "vector_store": vector_stats,
+                "embedding_service": embedding_info,
+            }
+
+        except Exception as exc:
+            self._last_error = str(exc)
+            logger.exception(
+                "Error getting index stats",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
             return {
                 "initialized": self._initialized,
-                "error": str(e),
+                "error": str(exc),
                 "last_error": self._last_error,
             }
     

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -4,19 +4,26 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+@pytest.fixture()
+def metrics_payload(client: TestClient) -> dict:
+    response = client.get("/api/v1/metrics")
+    assert response.status_code == 200
+    return response.json()
+
+
 @pytest.mark.api
-def test_metrics_structure(client: TestClient):
-    """Ensure the metrics endpoint matches the Streamlit UI expectations."""
-    first_response = client.get("/api/v1/metrics")
-    assert first_response.status_code == 200
+def test_metrics_structure(metrics_payload: dict):
+    """Ensure top-level keys exist."""
 
-    payload = first_response.json()
-    assert "timestamp" in payload
-    assert "application" in payload
-    assert "system" in payload
+    assert "timestamp" in metrics_payload
+    assert "application" in metrics_payload
+    assert "system" in metrics_payload
 
-    application = payload["application"]
-    for key in [
+
+@pytest.mark.api
+@pytest.mark.parametrize(
+    "field",
+    [
         "uptime_seconds",
         "total_requests",
         "active_connections",
@@ -25,18 +32,34 @@ def test_metrics_structure(client: TestClient):
         "llm_provider",
         "embedding_provider",
         "debug_mode",
-    ]:
-        assert key in application, f"Missing application metric: {key}"
+    ],
+)
+def test_application_metrics_fields(metrics_payload: dict, field: str) -> None:
+    """Application section exposes expected fields."""
 
-    system = payload["system"]
-    for key in [
+    assert field in metrics_payload["application"], f"Missing application metric: {field}"
+
+
+@pytest.mark.api
+@pytest.mark.parametrize(
+    "field",
+    [
         "cpu_percent",
         "memory_percent",
         "memory_used_mb",
         "memory_total_mb",
         "disk_percent",
-    ]:
-        assert key in system, f"Missing system metric: {key}"
+    ],
+)
+def test_system_metrics_fields(metrics_payload: dict, field: str) -> None:
+    """System section exposes expected fields."""
+
+    assert field in metrics_payload["system"], f"Missing system metric: {field}"
+
+
+@pytest.mark.api
+def test_total_requests_increments(client: TestClient, metrics_payload: dict) -> None:
+    """Total request counter increments on each call."""
 
     second_response = client.get("/api/v1/metrics")
     assert second_response.status_code == 200
@@ -44,6 +67,9 @@ def test_metrics_structure(client: TestClient):
     second_payload = second_response.json()
     assert (
         second_payload["application"]["total_requests"]
-        == application["total_requests"] + 1
+        == metrics_payload["application"]["total_requests"] + 1
     )
-    assert second_payload["application"]["uptime_seconds"] >= application["uptime_seconds"]
+    assert (
+        second_payload["application"]["uptime_seconds"]
+        >= metrics_payload["application"]["uptime_seconds"]
+    )


### PR DESCRIPTION
## Summary
- raise structured indexing service errors instead of returning empty results and convert them to HTTP errors in the solutions API
- consolidate health checks through a reusable helper and clarify configuration defaults
- guard the metrics request counter with an async lock and refactor the metrics endpoint tests to use parametrization

## Testing
- pytest tests/api/test_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cfa7a62be4832aa606f3bcd1ffd7d4

## Summary by Sourcery

Refine service reliability and observability by centralizing health checks, enforcing structured error handling in indexing and solutions endpoints, and improving metrics tracking and testing.

Enhancements:
- Abstract and unify service health checks with a safe executor and mapper
- Change indexing service methods to always initialize and raise structured IndexingServiceError on failure
- Map domain errors in solutions API to HTTP exceptions with proper status codes
- Protect the metrics request counter with an async lock for thread safety
- Refactor metrics endpoint tests to use fixtures, parametrization, and validate request count increments

Documentation:
- Clarify default settings in application configuration docstring

Tests:
- Revamp metrics endpoint tests with fixtures and parametrized field assertions
- Add test to verify total_requests counter increments as expected

Chores:
- Introduce IndexingServiceError exception
- Simplify query validation in request schema