### PR TITLE
Address review feedback for health and metrics

### DIFF
--- a/app/api/v1/health.py
+++ b/app/api/v1/health.py
@@ -3,21 +3,32 @@
 import inspect
 import time
 from datetime import datetime
-from typing import Any, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict
 
 from fastapi import APIRouter, status
 from pydantic import BaseModel
 
 from app.core.config import settings
+from app.core.exceptions import SolarWindsChatbotException
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 
 router = APIRouter()
 
+HealthCheckFn = Callable[[], Awaitable[Dict[str, Any]] | Dict[str, Any]]
+
+EXPECTED_HEALTH_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    SolarWindsChatbotException,
+    TimeoutError,
+    ConnectionError,
+    OSError,
+)
+
+
 class HealthResponse(BaseModel):
     """Health check response model."""
-    
+
     status: str
     timestamp: datetime
     version: str
@@ -30,22 +41,36 @@ class HealthResponse(BaseModel):
 _start_time = time.time()
 
 
-async def _safe_check(
-    component_name: str,
-    check_fn: Callable[[], Any],
-    mapper: Callable[[Any], Dict[str, Any]],
-) -> Dict[str, Any]:
+async def _resolve_result(result: Any) -> Dict[str, Any]:
+    """Normalize sync/async health check results into dictionaries."""
+
+    if inspect.isawaitable(result):
+        result = await result
+
+    if not isinstance(result, dict):  # pragma: no cover - defensive validation
+        raise TypeError("Health check functions must return a dictionary")
+
+    return result
+
+
+async def _safe_check(component_name: str, check_fn: HealthCheckFn) -> Dict[str, Any]:
     """Execute a health check function safely and map the result."""
 
     try:
-        result = check_fn()
-        if inspect.isawaitable(result):
-            result = await result
-
-        mapped = mapper(result)
-        if "status" not in mapped:
-            raise ValueError("Component mapper must include a 'status' field")
-        return mapped
+        result = await _resolve_result(check_fn())
+        if "status" not in result:
+            raise ValueError("Component health result must include a 'status' field")
+        return result
+    except EXPECTED_HEALTH_EXCEPTIONS as exc:
+        human_readable = component_name.replace("_", " ")
+        logger.warning(
+            "Health check component degraded",
+            extra={"component": component_name, "error": str(exc)},
+        )
+        return {
+            "status": "degraded",
+            "message": f"{human_readable} issue: {exc}",
+        }
     except Exception as exc:  # pragma: no cover - defensive logging path
         logger.exception(
             "Health check component failure",
@@ -58,28 +83,108 @@ async def _safe_check(
         }
 
 
-async def _get_index_stats() -> Dict[str, Any]:
+def _flag_check_factory(
+    get_data: Callable[[], Awaitable[Dict[str, Any]] | Dict[str, Any]],
+    flag_key: str,
+    *,
+    ok_status: str = "healthy",
+    fail_status: str = "degraded",
+    ok_msg: str = "",
+    fail_msg: str = "",
+    exclude_keys: tuple[str, ...] = (),
+) -> HealthCheckFn:
+    """Create a simple health check from a flag in a data payload."""
+
+    async def _check() -> Dict[str, Any]:
+        data = await _resolve_result(get_data())
+        is_ok = bool(data.get(flag_key))
+        message = ok_msg if is_ok else (data.get("error") or fail_msg)
+
+        result: Dict[str, Any] = {
+            "status": ok_status if is_ok else fail_status,
+            "message": message,
+        }
+
+        excluded_keys = set(exclude_keys)
+        excluded_keys.update({flag_key, "error"})
+
+        for key, value in data.items():
+            if key in excluded_keys:
+                continue
+            result[key] = value
+
+        return result
+
+    return _check
+
+
+async def check_vector_store() -> Dict[str, Any]:
+    """Evaluate the health of the vector store and indexing pipeline."""
+
     from app.services.indexing_service import indexing_service
 
-    return await indexing_service.get_index_stats()
+    stats = await indexing_service.get_index_stats()
+    health = await indexing_service.health_check()
+
+    if stats.get("initialized") and health.get("healthy"):
+        result: Dict[str, Any] = {
+            "status": "healthy",
+            "message": "Vector store operational",
+        }
+    else:
+        errors: list[str] = []
+        if not stats.get("initialized"):
+            errors.append(f"Stats: {stats.get('error', 'Not initialized')}")
+        if not health.get("healthy"):
+            errors.append(f"Health: {health.get('error', 'Unhealthy')}")
+        error_message = "; ".join(errors) if errors else "Service not initialized"
+        result = {
+            "status": "degraded",
+            "message": error_message,
+        }
+
+    # Preserve additional diagnostic details when available
+    if "vector_store" in stats:
+        result["vector_store"] = stats["vector_store"]
+    if "embedding_service" in stats:
+        result["embedding_service"] = stats["embedding_service"]
+    if "timestamp" in health:
+        result["checked_at"] = health["timestamp"]
+
+    return result
 
 
-async def _get_embedding_health() -> Dict[str, Any]:
-    from app.services.indexing_service import indexing_service
+async def check_llm_service() -> Dict[str, Any]:
+    """Evaluate the health of the LLM provider layer."""
 
-    return await indexing_service.health_check()
-
-
-async def _get_llm_health() -> Dict[str, Any]:
     from app.services.llm import llm_service
 
-    return await llm_service.health_check()
+    health = await llm_service.health_check()
+    status = health.get("status", "unknown")
+    message = health.get("error") or f"Provider: {health.get('provider', 'unknown')}"
+
+    result: Dict[str, Any] = {
+        "status": status,
+        "message": message,
+    }
+
+    for key in ("provider", "model"):
+        if health.get(key):
+            result[key] = health[key]
+
+    return result
 
 
-async def _get_sync_status() -> Dict[str, Any]:
+def _get_embedding_service_info() -> Awaitable[Dict[str, Any]]:
+    from app.services.embedding import embedding_service
+
+    return embedding_service.get_service_info()
+
+
+def _get_sync_status() -> Awaitable[Dict[str, Any]]:
     from app.services.sync_service import sync_service
 
-    return await sync_service.get_sync_status()
+    return sync_service.get_sync_status()
 
 
 def _get_solarwinds_configuration() -> Dict[str, Any]:
@@ -87,12 +192,41 @@ def _get_solarwinds_configuration() -> Dict[str, Any]:
 
     client = getattr(solarwinds_service, "client", None)
     configured = bool(client and client.api_key)
-    message = (
-        "SolarWinds API configured"
-        if configured
-        else "SolarWinds API not configured"
-    )
-    return {"configured": configured, "message": message}
+    return {
+        "configured": configured,
+        "message": (
+            "SolarWinds API configured"
+            if configured
+            else "SolarWinds API not configured"
+        ),
+    }
+
+
+check_embedding_service = _flag_check_factory(
+    _get_embedding_service_info,
+    flag_key="initialized",
+    ok_msg="Embedding service operational",
+    fail_msg="Embedding service degraded",
+)
+
+
+check_sync_service = _flag_check_factory(
+    _get_sync_status,
+    flag_key="service_running",
+    ok_msg="Sync service running",
+    fail_msg="Sync service not running",
+    exclude_keys=("last_sync_time", "next_sync_time"),
+)
+
+
+check_solarwinds_api = _flag_check_factory(
+    _get_solarwinds_configuration,
+    flag_key="configured",
+    ok_status="healthy",
+    fail_status="disabled",
+    ok_msg="SolarWinds API configured",
+    fail_msg="SolarWinds API not configured",
+)
 
 
 @router.get(
@@ -120,64 +254,17 @@ async def health_check() -> HealthResponse:
     }
 
     service_checks = [
-        (
-            "vector_store",
-            _get_index_stats,
-            lambda stats: {
-                "status": "healthy" if stats.get("initialized") else "degraded",
-                "message": (
-                    "Vector store operational"
-                    if stats.get("initialized")
-                    else stats.get("error", "Service not initialized")
-                ),
-            },
-        ),
-        (
-            "embedding_service",
-            _get_embedding_health,
-            lambda health: {
-                "status": "healthy" if health.get("healthy") else "degraded",
-                "message": health.get("error") or "Embedding service operational",
-            },
-        ),
-        (
-            "llm_service",
-            _get_llm_health,
-            lambda health: {
-                "status": health.get("status", "unknown"),
-                "message": health.get("error")
-                or f"Provider: {health.get('provider', 'unknown')}",
-            },
-        ),
-        (
-            "sync_service",
-            _get_sync_status,
-            lambda sync_status: {
-                "status": "healthy"
-                if sync_status.get("service_running")
-                else "degraded",
-                "message": (
-                    "Sync service running"
-                    if sync_status.get("service_running")
-                    else "Sync service not running"
-                ),
-            },
-        ),
-        (
-            "solarwinds_api",
-            _get_solarwinds_configuration,
-            lambda config: {
-                "status": "healthy" if config.get("configured") else "disabled",
-                "message": config.get("message", "SolarWinds API not configured"),
-            },
-        ),
+        ("vector_store", check_vector_store),
+        ("embedding_service", check_embedding_service),
+        ("llm_service", check_llm_service),
+        ("sync_service", check_sync_service),
+        ("solarwinds_api", check_solarwinds_api),
     ]
 
-    for component_name, check_fn, mapper in service_checks:
+    for component_name, check_fn in service_checks:
         components[component_name] = await _safe_check(
             component_name,
             check_fn,
-            mapper,
         )
     
     logger.info("Health check requested", extra={

--- a/app/api/v1/metrics.py
+++ b/app/api/v1/metrics.py
@@ -61,6 +61,30 @@ _total_requests = 0
 _request_counter_lock: asyncio.Lock | None = None
 
 
+def get_uptime_seconds() -> float:
+    """Return the number of seconds the application has been running."""
+
+    return max(time.time() - _start_time, 0.0)
+
+
+def reset_metrics_state() -> None:
+    """Reset module-level metrics state for testing and service restarts."""
+
+    global _start_time
+    global _total_requests
+    global _request_counter_lock
+
+    previous_start = globals().get("_start_time", 0.0)
+    new_start_time = time.time() + 1e-3
+    if new_start_time <= previous_start:
+        # Guarantee monotonicity even on coarse time resolutions
+        new_start_time = previous_start + 1e-3
+
+    _start_time = new_start_time
+    _total_requests = 0
+    _request_counter_lock = None
+
+
 async def _increment_request_count() -> int:
     """Increment the total request counter in a thread-safe manner."""
 
@@ -89,8 +113,7 @@ async def get_metrics() -> MetricsResponse:
     Returns:
         ApplicationMetrics: Current application and system metrics
     """
-    current_time = time.time()
-    uptime = current_time - _start_time
+    uptime = get_uptime_seconds()
     total_requests = await _increment_request_count()
     
     # Get system metrics
@@ -148,8 +171,7 @@ async def get_prometheus_metrics():
     Returns:
         str: Metrics in Prometheus exposition format
     """
-    current_time = time.time()
-    uptime = current_time - _start_time
+    uptime = get_uptime_seconds()
     
     # Get system metrics
     cpu_percent = psutil.cpu_percent(interval=0.1)

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -1,7 +1,21 @@
 """Tests for the metrics endpoint."""
 
+import time
+
 import pytest
 from fastapi.testclient import TestClient
+
+import app.api.v1.metrics as metrics_module
+from app.api.v1.metrics import get_uptime_seconds, reset_metrics_state
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_globals() -> None:
+    """Ensure metrics module state is reset before and after each test."""
+
+    reset_metrics_state()
+    yield
+    reset_metrics_state()
 
 
 @pytest.fixture()
@@ -73,3 +87,22 @@ def test_total_requests_increments(client: TestClient, metrics_payload: dict) ->
         second_payload["application"]["uptime_seconds"]
         >= metrics_payload["application"]["uptime_seconds"]
     )
+
+
+@pytest.mark.api
+def test_metrics_uptime_resets_on_reset_metrics_state() -> None:
+    """Ensure uptime and start time update when metrics state resets."""
+
+    time.sleep(0.1)
+    uptime_before = get_uptime_seconds()
+    start_time_before = metrics_module._start_time
+
+    reset_metrics_state()
+
+    uptime_after = get_uptime_seconds()
+    start_time_after = metrics_module._start_time
+
+    assert uptime_after < 0.05, f"Uptime after reset should be near zero, got {uptime_after}"
+    assert (
+        start_time_after > start_time_before
+    ), "_start_time should be updated after reset"


### PR DESCRIPTION
## Summary
- refactor health check utilities with typed wrappers, expected exception handling, and a flag-based factory to consolidate component checks while surfacing vector-store degradation details and hiding sync scheduler timings
- add metrics helpers to expose uptime queries and reset state safely, ensuring monotonic start times and reusing the helper inside metrics and Prometheus responses
- extend metrics tests with an automatic state-reset fixture and a new uptime-reset scenario validating the helper behaviour

## Testing
- pytest tests/api/test_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d037874094832aa8af43d97961e6e1

## Summary by Sourcery

Consolidate health check logic around typed wrappers, unified error handling, and a flag-based factory; introduce uptime and reset helpers for metrics; and update tests to validate metrics state reset behavior.

New Features:
- Add HealthCheckFn alias and EXPECTED_HEALTH_EXCEPTIONS for standardized health error handling
- Introduce _flag_check_factory and dedicated check_* functions for vector store, LLM, embedding, sync, and SolarWinds components
- Add get_uptime_seconds and reset_metrics_state helpers to manage metrics module state

Enhancements:
- Refactor health check execution with _resolve_result and unified _safe_check, removing custom mappers
- Update metrics and Prometheus endpoints to use get_uptime_seconds
- Ensure monotonic start time in metrics reset to avoid negative uptime

Tests:
- Add automatic reset_metrics_state fixture to reset metrics state around tests
- Add test for uptime reset behavior verifying monotonic start time