### PR TITLE
Add vector store connection retry and disable reset

### DIFF
--- a/app/services/vector_store.py
+++ b/app/services/vector_store.py
@@ -10,6 +10,8 @@ import chromadb
 from chromadb.api.models.Collection import Collection
 from chromadb.config import Settings as ChromaSettings
 
+from tenacity import retry, stop_after_attempt, wait_exponential
+
 from app.core.config import settings
 from app.core.exceptions import VectorStoreError
 from app.core.logging import get_logger
@@ -54,6 +56,7 @@ class VectorStoreService:
             logger.error(f"Failed to connect to Chroma: {str(e)}")
             raise VectorStoreError(f"Chroma connection failed: {str(e)}")
     
+    @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=2, max=15))
     def _create_client(self) -> chromadb.ClientAPI:
         """Create Chroma client (sync operation)."""
         try:
@@ -63,7 +66,7 @@ class VectorStoreService:
                 port=settings.chroma_port,
                 settings=ChromaSettings(
                     anonymized_telemetry=False,
-                    allow_reset=True,
+                    allow_reset=False,
                 )
             )
             
@@ -80,7 +83,7 @@ class VectorStoreService:
                     path="./chroma_db",
                     settings=ChromaSettings(
                         anonymized_telemetry=False,
-                        allow_reset=True,
+                        allow_reset=False,
                     )
                 )
             except Exception as fallback_error:


### PR DESCRIPTION
## Summary
- Adds tenacity retry (5 attempts, exponential backoff 2-15s) to ChromaDB client creation for container startup resilience
- Disables `allow_reset` in ChromaSettings to prevent accidental database wipes

## Test plan
- [ ] Verify `python -c "from app.services.vector_store import vector_store_service"` imports cleanly
- [ ] Verify retry behavior when ChromaDB starts slowly

## Summary by Sourcery

Add connection retry logic and safer configuration for the Chroma vector store client.

Enhancements:
- Add retry with exponential backoff to Chroma client creation to improve resilience during startup.
- Disable Chroma allow_reset in both server and local client configurations to prevent accidental database resets.