### PR TITLE
Prevent concurrent syncs when Redis is unavailable

### DIFF
--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -28,6 +28,7 @@ class SyncStateManager:
         self.state_key = "solarwinds:sync_state"
         self.lock_key = "solarwinds:sync_lock"
         self.stats_key = "solarwinds:sync_stats"
+        self._local_lock_held = False
         
     async def connect(self) -> None:
         """Connect to Redis."""
@@ -90,8 +91,11 @@ class SyncStateManager:
             True if lock acquired, False otherwise
         """
         if not self.redis_client:
-            return True  # Allow sync if Redis unavailable
-            
+            if self._local_lock_held:
+                return False
+            self._local_lock_held = True
+            return True
+
         try:
             result = await self.redis_client.set(
                 self.lock_key,
@@ -107,6 +111,7 @@ class SyncStateManager:
     async def release_sync_lock(self) -> None:
         """Release the sync lock."""
         if not self.redis_client:
+            self._local_lock_held = False
             return
             
         try:
@@ -117,7 +122,7 @@ class SyncStateManager:
     async def is_sync_in_progress(self) -> bool:
         """Check if sync is currently in progress."""
         if not self.redis_client:
-            return False
+            return self._local_lock_held
             
         try:
             return bool(await self.redis_client.exists(self.lock_key))


### PR DESCRIPTION
## Summary
- Adds in-process lock fallback when Redis client is unavailable
- `acquire_sync_lock` now returns False if already held (was returning True unconditionally)
- `release_sync_lock` and `is_sync_in_progress` use local state as fallback

## Test plan
- [ ] Verify sync lock prevents concurrent syncs without Redis
- [ ] Verify `python -c "from app.services.sync_service import sync_service"` imports cleanly

## Summary by Sourcery

Add an in-process fallback lock mechanism to prevent concurrent syncs when Redis is unavailable and align sync lock helpers with this fallback state.

Bug Fixes:
- Ensure sync lock attempts fail when a local in-process lock is already held if Redis is unavailable, preventing concurrent sync runs.

Enhancements:
- Track sync lock state locally when Redis is unavailable so lock acquisition, release, and status checks behave consistently without Redis.