### PR TITLE
Add nginx reverse proxy for production deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,21 @@ services:
       - solarwinds-network
     command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
 
+  # Nginx Reverse Proxy
+  nginx:
+    image: nginx:alpine
+    container_name: solarwinds-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api
+      - frontend
+    restart: unless-stopped
+    networks:
+      - solarwinds-network
+
 volumes:
   chroma-data:
     driver: local

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,52 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile    on;
+    keepalive_timeout 65;
+
+    upstream api {
+        server api:8000;
+    }
+
+    upstream frontend {
+        server frontend:8501;
+    }
+
+    server {
+        listen 80;
+
+        # Security headers
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options DENY always;
+
+        # Proxy settings
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 60s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        location /api/ {
+            proxy_pass http://api;
+        }
+
+        location /_stcore/stream {
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location / {
+            proxy_pass http://frontend;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Creates `nginx.conf` proxying `/api/` to FastAPI and `/` to Streamlit
- Handles Streamlit WebSocket upgrade at `/_stcore/stream`
- Sets security headers and proxy timeouts (60s read for chat endpoint)
- Adds nginx service to docker-compose.yml as the single public entry point (port 80)

## Test plan
- [ ] `docker compose config` validates YAML
- [ ] Verify nginx proxies API and frontend correctly
- [ ] Verify Streamlit WebSocket works through nginx

## Summary by Sourcery

Add an Nginx reverse proxy service as the single public entry point for the API and Streamlit frontend.

Deployment:
- Introduce an Nginx container fronting the API and frontend services in docker-compose, exposing port 80.
- Add Nginx configuration to route /api/ requests to FastAPI, route root paths to the Streamlit frontend, and support Streamlit WebSocket connections with security headers and timeouts.