### PR TITLE
Harden Docker Compose: lock down ports, Redis auth, disable ChromaDB reset

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
+    ports:
+      - "8000:8000"
     environment:
       - DEBUG=true
       - LOG_LEVEL=DEBUG
@@ -17,12 +19,24 @@ services:
       - .:/app  # Mount source code for live reloading
       - /app/.venv  # Exclude virtual environment from mount
     command: ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
-    
-  # Development overrides for frontend service  
+
+  # Development overrides for frontend service
   frontend:
+    ports:
+      - "8501:8501"
     volumes:
       - .:/app
       - /app/.venv
     environment:
       - API_BASE_URL=http://api:8000
     command: ["python", "-m", "streamlit", "run", "streamlit_app.py", "--server.address", "0.0.0.0", "--server.port", "8501", "--server.headless", "true", "--server.fileWatcherType", "poll"]
+
+  # Development overrides for chromadb - expose port for direct access
+  chromadb:
+    ports:
+      - "8001:8000"
+
+  # Development overrides for redis - expose port for direct access
+  redis:
+    ports:
+      - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       dockerfile: Dockerfile
       target: production
     container_name: solarwinds-api
-    ports:
-      - "8000:8000"
     environment:
       - DEBUG=false
       - LOG_LEVEL=INFO
@@ -17,7 +15,7 @@ services:
       - EMBEDDING_PROVIDER=local
       - CHROMA_HOST=chromadb
       - CHROMA_PORT=8000
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379
       - REDIS_DB=0
       - REDIS_ENABLED=true
       - ENABLE_MOCK_DATA=true
@@ -45,8 +43,6 @@ services:
       dockerfile: Dockerfile
       target: production
     container_name: solarwinds-frontend
-    ports:
-      - "8501:8501"
     environment:
       - API_BASE_URL=http://api:8000
     command: ["python", "-m", "streamlit", "run", "streamlit_app.py", "--server.address", "0.0.0.0", "--server.port", "8501", "--server.headless", "true"]
@@ -66,13 +62,11 @@ services:
   chromadb:
     image: chromadb/chroma:latest
     container_name: solarwinds-chromadb
-    ports:
-      - "8001:8000"
     environment:
       - CHROMA_HOST=0.0.0.0
       - CHROMA_PORT=8000
       - ANONYMIZED_TELEMETRY=false
-      - ALLOW_RESET=true
+      - ALLOW_RESET=false
     volumes:
       - chroma-data:/chroma/chroma
     healthcheck:
@@ -89,8 +83,6 @@ services:
   redis:
     image: redis:7-alpine
     container_name: solarwinds-redis
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -101,7 +93,7 @@ services:
     restart: unless-stopped
     networks:
       - solarwinds-network
-    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD:-changeme}
 
 volumes:
   chroma-data:


### PR DESCRIPTION
## Summary
- Remove direct host port exposure from all services in production compose
- Add Redis password authentication (`--requirepass`)
- Update API service REDIS_URL to include password
- Disable `ALLOW_RESET` on ChromaDB to prevent accidental wipes
- Add port overrides in `docker-compose.dev.yml` for development access

## Test plan
- [ ] `docker compose config` validates production YAML
- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` validates dev override
- [ ] Redis requires password, ChromaDB reset disabled

## Summary by Sourcery

Tighten Docker Compose security by removing host port exposure in production, enabling Redis authentication, and disabling destructive ChromaDB operations while adding explicit port mappings for local development.

Enhancements:
- Configure Redis to require a password and propagate it via REDIS_URL for the API service.
- Disable ChromaDB reset capability in production to prevent accidental data loss.
- Restrict production services from binding to host ports, relying instead on internal networking.
- Add development-only port mappings for API, frontend, ChromaDB, and Redis to preserve local access without exposing them in production.