### PR TITLE
Add JSON production logging and request correlation IDs

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -6,14 +6,20 @@ import sys
 from typing import Any, Dict
 
 from app.core.config import settings
+from app.core.middleware import RequestIDFilter
 
 
 def setup_logging() -> None:
     """Setup application logging configuration."""
-    
+
     logging_config: Dict[str, Any] = {
         "version": 1,
         "disable_existing_loggers": False,
+        "filters": {
+            "request_id": {
+                "()": RequestIDFilter,
+            },
+        },
         "formatters": {
             "default": {
                 "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -25,7 +31,7 @@ def setup_logging() -> None:
             },
             "json": {
                 "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
-                "format": "%(asctime)s %(name)s %(levelname)s %(pathname)s %(lineno)d %(message)s",
+                "format": "%(asctime)s %(name)s %(levelname)s %(pathname)s %(lineno)d %(message)s %(request_id)s",
                 "datefmt": "%Y-%m-%d %H:%M:%S",
             },
         },
@@ -33,7 +39,8 @@ def setup_logging() -> None:
             "console": {
                 "class": "logging.StreamHandler",
                 "level": settings.log_level,
-                "formatter": "detailed" if settings.debug else "default",
+                "formatter": "detailed" if settings.debug else "json",
+                "filters": ["request_id"],
                 "stream": sys.stdout,
             },
         },

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,37 @@
+"""Request correlation ID middleware.
+
+To register this middleware in app/main.py, add:
+    from app.core.middleware import RequestIDMiddleware
+    app.add_middleware(RequestIDMiddleware)
+"""
+
+import logging
+import uuid
+from contextvars import ContextVar
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Context variable for request ID -- accessible from anywhere in the async call chain
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIDFilter(logging.Filter):
+    """Logging filter that injects the current request ID into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get("")  # type: ignore[attr-defined]
+        return True
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Middleware that assigns a unique request ID to each request."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        request_id_var.set(request_id)
+
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response


### PR DESCRIPTION
## Summary
- Production logs now use structured JSON format (debug keeps human-readable)
- New `RequestIDMiddleware` reads `X-Request-ID` from incoming requests or generates a UUID
- `RequestIDFilter` injects `request_id` into all log records
- Middleware registration instructions in docstring (main.py wired separately)

## Test plan
- [ ] Verify `python -c "from app.core.middleware import RequestIDMiddleware; print('OK')"`
- [ ] Verify JSON log output when DEBUG=false
- [ ] Verify X-Request-ID appears in response headers

## Summary by Sourcery

Introduce request correlation IDs and switch production logging to structured JSON with request context.

New Features:
- Add RequestIDMiddleware to generate or propagate X-Request-ID per incoming request and return it in response headers.
- Add RequestIDFilter and contextvar-based request ID storage to make the current request ID available to log records.
- Enable JSON-formatted console logging in non-debug environments including the request_id field in each log entry.

Enhancements:
- Wire the request ID logging filter into the logging configuration so all console logs automatically include correlation IDs.