### PR TITLE
Add API key auth, rate limiting, security headers, fix debug override

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,21 @@
+"""API key authentication dependency."""
+
+import secrets
+
+from fastapi import HTTPException, Request
+
+from app.core.config import settings
+
+
+async def require_api_key(request: Request) -> None:
+    """Validate the X-API-Key header against the configured API key.
+
+    If ``settings.api_key`` is *None* (the default), authentication is
+    skipped entirely so local development works without extra setup.
+    """
+    if settings.api_key is None:
+        return
+
+    provided = request.headers.get("X-API-Key", "")
+    if not provided or not secrets.compare_digest(provided, settings.api_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,9 +24,7 @@ class Settings(BaseSettings):
     # API Settings  
     api_v1_prefix: str = Field(default="/api/v1", description="API v1 prefix")
     cors_origins: list[str] = Field(default=[
-        "http://localhost:3000",      # Next.js (original plan)
-        "http://localhost:8501",      # Streamlit local development
-        "https://*.streamlit.app"     # Streamlit Cloud deployment
+        "http://localhost:8501",
     ], description="CORS allowed origins")
 
     # SolarWinds API Settings
@@ -75,13 +73,9 @@ class Settings(BaseSettings):
     
     # Security Settings
     allowed_hosts: list[str] = Field(default=["*"], description="Allowed hosts")
+    api_key: Optional[str] = Field(default=None, description="API key for request authentication")
+    rate_limit_per_minute: int = Field(default=60, description="Max API requests per minute per client")
 
 
 # Global settings instance
-# Create settings with explicit environment variables for development
-import os
-os.environ.setdefault('DEBUG', 'true')
-os.environ.setdefault('LLM_PROVIDER', 'ollama')
-os.environ.setdefault('EMBEDDING_PROVIDER', 'local')
-
 settings = Settings()

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -1,0 +1,43 @@
+"""In-memory sliding-window rate limiter (FastAPI dependency)."""
+
+import time
+
+from fastapi import HTTPException, Request
+
+from app.core.config import settings
+
+
+class _SlidingWindowRateLimiter:
+    """Track request timestamps per client in a sliding 60-second window."""
+
+    def __init__(self) -> None:
+        self._requests: dict[str, list[float]] = {}
+
+    def _client_key(self, request: Request) -> str:
+        """Return a rate-limit key: API key if present, otherwise client IP."""
+        api_key = request.headers.get("X-API-Key")
+        if api_key:
+            return f"key:{api_key}"
+        client_host = request.client.host if request.client else "unknown"
+        return f"ip:{client_host}"
+
+    async def __call__(self, request: Request) -> None:
+        key = self._client_key(request)
+        now = time.monotonic()
+        window_start = now - 60.0
+
+        # Prune timestamps outside the window; drop idle clients
+        timestamps = [t for t in self._requests.get(key, []) if t > window_start]
+
+        if len(timestamps) >= settings.rate_limit_per_minute:
+            self._requests[key] = timestamps
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded. Try again later.",
+            )
+
+        timestamps.append(now)
+        self._requests[key] = timestamps
+
+
+rate_limiter = _SlidingWindowRateLimiter()

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-from fastapi import FastAPI, Request, status
+from fastapi import Depends, FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -11,7 +11,9 @@ from app.api.v1.health import router as health_router
 from app.api.v1.chat import router as chat_router
 from app.api.v1.solutions import router as solutions_router
 from app.api.v1.metrics import router as metrics_router
+from app.core.auth import require_api_key
 from app.core.config import settings
+from app.core.rate_limit import rate_limiter
 from app.core.exceptions import SolarWindsChatbotException
 from app.core.logging import setup_logging, get_logger
 from app.services.sync_service import sync_service
@@ -92,6 +94,16 @@ def create_application() -> FastAPI:
         lifespan=lifespan,
     )
     
+    # Security headers middleware
+    @app.middleware("http")
+    async def add_security_headers(request: Request, call_next) -> Response:  # type: ignore[type-arg]
+        response: Response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     # CORS middleware
     app.add_middleware(
         CORSMiddleware,
@@ -100,30 +112,36 @@ def create_application() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    
-    # Include routers
+
+    # Shared auth + rate-limit dependencies for protected routers
+    _protected = [Depends(require_api_key), Depends(rate_limiter)]
+
+    # Include routers — health stays unauthenticated for Docker healthchecks
     app.include_router(
         health_router,
         prefix=settings.api_v1_prefix,
         tags=["health"],
     )
-    
+
     app.include_router(
         chat_router,
         prefix=settings.api_v1_prefix,
         tags=["chat"],
+        dependencies=_protected,
     )
-    
+
     app.include_router(
         solutions_router,
         prefix=settings.api_v1_prefix,
         tags=["solutions"],
+        dependencies=_protected,
     )
-    
+
     app.include_router(
         metrics_router,
         prefix=settings.api_v1_prefix,
         tags=["metrics"],
+        dependencies=_protected,
     )
     
     return app


### PR DESCRIPTION
## Summary
- **Auth**: X-API-Key header validation, skipped when API_KEY not set (dev mode)
- **Rate limiting**: In-memory sliding window, 60 req/min per client by default
- **Security headers**: X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy
- **Config fix**: Remove `os.environ.setdefault('DEBUG', 'true')` that forced debug mode
- **CORS**: Tighten defaults to `localhost:8501` only
- Health endpoints remain unauthenticated for Docker healthchecks

## Test plan
- [ ] `python -c "from app.main import app; print('OK')"` imports cleanly
- [ ] API returns 401 without X-API-Key when API_KEY is set
- [ ] API returns 429 when rate limit exceeded
- [ ] Security headers present on all responses
- [ ] Health endpoints accessible without auth

## Summary by Sourcery

Introduce API key authentication, request rate limiting, and security headers while tightening CORS and removing a debug-mode override from configuration.

New Features:
- Add API key–based authentication via X-API-Key header with optional enforcement based on configuration.
- Add an in-memory sliding-window rate limiter configurable by per-minute request limit.
- Apply standard security headers to all HTTP responses to harden the API surface.

Enhancements:
- Restrict CORS allowed origins to the local Streamlit development origin.
- Protect chat, solutions, and metrics routers behind shared auth and rate-limit dependencies while keeping health endpoints open.

Chores:
- Remove hard-coded environment defaults that previously forced debug mode and specific providers in configuration.