### PR TITLE
Add test infrastructure: service mocking, auth tests, error tests

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,42 @@
+"""API key authentication module."""
+
+from typing import Optional
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+from app.core.config import settings
+
+# API key header scheme (auto_error=False so we can handle missing keys ourselves)
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(
+    api_key: Optional[str] = Security(api_key_header),
+) -> Optional[str]:
+    """
+    Verify the API key from the request header.
+
+    If ``settings.api_key`` is not configured (None or empty), authentication
+    is disabled and all requests pass through.  Otherwise the caller must
+    supply a matching ``X-API-Key`` header.
+    """
+    configured_key = settings.api_key
+
+    # No key configured -- auth disabled
+    if not configured_key:
+        return None
+
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key",
+        )
+
+    if api_key != configured_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+
+    return api_key

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
     response_timeout_seconds: int = Field(default=30, description="Response timeout in seconds")
     
     # Security Settings
+    api_key: Optional[str] = Field(default=None, description="API key for endpoint authentication (disabled when None)")
     allowed_hosts: list[str] = Field(default=["*"], description="Allowed hosts")
 
 

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,113 @@
+"""Tests for API key authentication."""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+
+from app.core.auth import verify_api_key
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a tiny app that uses the verify_api_key dependency
+# ---------------------------------------------------------------------------
+
+def _make_auth_app() -> FastAPI:
+    """Create a minimal FastAPI app with the auth dependency on a test route."""
+    test_app = FastAPI()
+
+    @test_app.get("/protected")
+    async def protected_route(key=Depends(verify_api_key)):
+        return {"status": "ok"}
+
+    @test_app.get("/health")
+    async def health_route():
+        """Health-style endpoint with no auth dependency."""
+        return {"status": "healthy"}
+
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDisabled:
+    """When api_key is not configured (None), all endpoints pass without auth."""
+
+    def test_no_auth_when_api_key_not_set(self):
+        """Protected endpoint should be accessible when API_KEY is not configured."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = None
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/protected")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
+    def test_no_auth_when_api_key_empty_string(self):
+        """Protected endpoint should be accessible when API_KEY is empty string."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/protected")
+            assert response.status_code == 200
+
+
+class TestAuthEnabled:
+    """When api_key is configured, requests must supply a valid X-API-Key header."""
+
+    def test_missing_header_returns_401(self):
+        """Request without X-API-Key header should return 401."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/protected")
+            assert response.status_code == 401
+
+    def test_wrong_key_returns_401(self):
+        """Request with incorrect API key should return 401."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/protected", headers={"X-API-Key": "wrong-key"})
+            assert response.status_code == 401
+
+    def test_correct_key_returns_200(self):
+        """Request with correct API key should succeed."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get(
+                "/protected", headers={"X-API-Key": "test-secret-key"}
+            )
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
+
+class TestHealthAlwaysAccessible:
+    """Health endpoints without auth dependency should always be accessible."""
+
+    def test_health_accessible_when_api_key_configured(self):
+        """Health endpoint (no auth dependency) remains accessible regardless of api_key setting."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/health")
+            assert response.status_code == 200
+            assert response.json() == {"status": "healthy"}
+
+    def test_health_accessible_when_api_key_not_set(self):
+        """Health endpoint remains accessible when api_key is None."""
+        with patch("app.core.auth.settings") as mock_settings:
+            mock_settings.api_key = None
+            app = _make_auth_app()
+            client = TestClient(app)
+            response = client.get("/health")
+            assert response.status_code == 200

--- a/tests/api/test_error_handling.py
+++ b/tests/api/test_error_handling.py
@@ -1,0 +1,67 @@
+"""Tests for graceful error handling across API endpoints."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.services.indexing_service import indexing_service
+from app.services.llm import llm_service
+
+
+@pytest.mark.api
+class TestChatErrorHandling:
+    """Chat endpoint should degrade gracefully when services fail."""
+
+    def test_chat_returns_graceful_response_when_search_fails(self, client: TestClient):
+        """When search_solutions raises, chat should still return 200 with an error message."""
+        with patch.object(
+            indexing_service,
+            "search_solutions",
+            new_callable=AsyncMock,
+            side_effect=Exception("vector store unavailable"),
+        ):
+            response = client.post("/api/v1/chat", json={"query": "test query"})
+            assert response.status_code == 200
+            data = response.json()
+            assert "answer" in data
+            # The answer should indicate an error occurred
+            assert len(data["answer"]) > 0
+
+    def test_chat_returns_graceful_response_when_llm_fails(self, client: TestClient):
+        """When LLM generation raises, chat should still return 200 with a fallback."""
+        with patch.object(
+            llm_service,
+            "generate_response",
+            new_callable=AsyncMock,
+            side_effect=Exception("LLM service down"),
+        ):
+            response = client.post("/api/v1/chat", json={"query": "test query"})
+            assert response.status_code == 200
+            data = response.json()
+            assert "answer" in data
+            assert len(data["answer"]) > 0
+
+
+@pytest.mark.api
+class TestRouteErrors:
+    """Basic HTTP error scenarios."""
+
+    def test_unknown_route_returns_404(self, client: TestClient):
+        """Requesting a non-existent route should return 404."""
+        response = client.get("/api/v1/nonexistent")
+        assert response.status_code == 404
+
+    def test_chat_with_invalid_json_returns_422(self, client: TestClient):
+        """POST to chat with missing required fields should return 422."""
+        response = client.post("/api/v1/chat", json={})
+        assert response.status_code == 422
+
+    def test_chat_with_empty_body_returns_422(self, client: TestClient):
+        """POST to chat with no body at all should return 422."""
+        response = client.post(
+            "/api/v1/chat",
+            content="not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 422

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -9,29 +9,26 @@ from httpx import AsyncClient
 def test_health_endpoint(client: TestClient):
     """Test the health check endpoint returns correct status."""
     response = client.get("/api/v1/health")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Check basic structure
     assert "status" in data
     assert "timestamp" in data
     assert "components" in data
-    
-    # Check components exist
+
+    # The base components are always present
     components = data["components"]
-    expected_components = [
-        "vector_store",
-        "embedding_service", 
-        "llm_service",
-        "sync_service",
-        "solarwinds_api"
-    ]
-    
-    for component in expected_components:
+    for component in ["api", "config", "logging"]:
         assert component in components
         assert "status" in components[component]
         assert "message" in components[component]
+
+    # Verify that each component entry has the expected shape
+    for name, info in components.items():
+        assert isinstance(info, dict), f"Component '{name}' should be a dict"
+        assert "status" in info, f"Component '{name}' missing 'status' key"
 
 
 @pytest.mark.api
@@ -39,10 +36,10 @@ def test_health_endpoint(client: TestClient):
 async def test_health_endpoint_async(async_client: AsyncClient):
     """Test the health check endpoint with async client."""
     response = await async_client.get("/api/v1/health")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert data["status"] in ["healthy", "degraded", "unhealthy"]
     assert isinstance(data["components"], dict)
 
@@ -51,10 +48,10 @@ async def test_health_endpoint_async(async_client: AsyncClient):
 def test_root_endpoint(client: TestClient):
     """Test the root endpoint returns correct information."""
     response = client.get("/")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert "message" in data
     assert "version" in data
     assert "docs" in data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,73 @@
 """Test configuration and fixtures for the SolarWinds IT Solutions Chatbot."""
 
 import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
+# Ensure test mode
+os.environ["DEBUG"] = "true"
+
 from app.main import app
 from app.core.config import settings
+from app.services.indexing_service import indexing_service
+from app.services.llm import llm_service
+from app.services.sync_service import sync_service
+
+
+@pytest.fixture(autouse=True, scope="session")
+def mock_services():
+    """Patch external service methods so tests run without Docker services."""
+    patches = [
+        # Indexing service
+        patch.object(indexing_service, "initialize", new_callable=AsyncMock),
+        patch.object(indexing_service, "cleanup", new_callable=AsyncMock),
+        patch.object(
+            indexing_service,
+            "search_solutions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch.object(
+            indexing_service,
+            "health_check",
+            new_callable=AsyncMock,
+            return_value={"healthy": True},
+        ),
+        # LLM service
+        patch.object(llm_service, "initialize", new_callable=AsyncMock),
+        patch.object(llm_service, "cleanup", new_callable=AsyncMock),
+        patch.object(
+            llm_service,
+            "generate_response",
+            new_callable=AsyncMock,
+            return_value="Mock response",
+        ),
+        patch.object(
+            llm_service,
+            "health_check",
+            new_callable=AsyncMock,
+            return_value={"provider": "mock", "status": "healthy"},
+        ),
+        # Sync service
+        patch.object(sync_service, "start", new_callable=AsyncMock),
+        patch.object(sync_service, "stop", new_callable=AsyncMock),
+        patch.object(
+            sync_service,
+            "get_sync_status",
+            new_callable=AsyncMock,
+            return_value={"service_running": False},
+        ),
+    ]
+
+    started = [p.start() for p in patches]
+    yield started
+    for p in patches:
+        p.stop()
 
 
 @pytest.fixture(scope="session")
@@ -52,16 +112,14 @@ def sample_solution_data():
         "category": "Hardware",
         "content": "This is a test solution for printer issues. Follow these steps to resolve common printer problems.",
         "tags": ["printer", "hardware", "troubleshooting"],
-        "url": "https://solarwinds.example.com/solutions/test-001"
+        "url": "https://solarwinds.example.com/solutions/test-001",
     }
 
 
 @pytest.fixture
 def sample_chat_request():
     """Provide sample chat request data for testing."""
-    return {
-        "query": "How do I fix printer spooler issues?"
-    }
+    return {"query": "How do I fix printer spooler issues?"}
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- **conftest.py**: Autouse session fixture mocks all 11 external service methods (indexing, LLM, sync) so `pytest` runs without Docker
- **test_auth.py**: 7 tests covering auth disabled (None/empty), auth enabled (missing/wrong/correct key), health always accessible
- **test_error_handling.py**: 5 tests for graceful chat failures and HTTP error scenarios (404, 422)
- **test_health.py**: Fixed expected component keys from old names to actual (`api`, `config`, `logging`)
- **auth.py**: Minimal stub for test imports (full auth in PR #13)

## Test plan
- [ ] `pytest tests/ -x --tb=short` passes without Docker services

## Summary by Sourcery

Add API key authentication support and expand test coverage for auth, error handling, and health endpoints while enabling tests to run without external services.

New Features:
- Introduce API key configuration setting and verification dependency for securing endpoints with an X-API-Key header.

Bug Fixes:
- Align health endpoint tests with current component keys and data shape.

Enhancements:
- Mock external indexing, LLM, and sync services in a session-level test fixture so the test suite runs without Docker-based dependencies.
- Ensure debug mode is enabled during tests via environment configuration.

Tests:
- Add comprehensive tests for authentication behavior when API key auth is disabled or enabled, including health endpoint accessibility.
- Add tests covering graceful chat failures when backend services throw errors and basic HTTP error scenarios for unknown routes and invalid chat payloads.
- Refine health endpoint tests to validate presence and structure of base components.